### PR TITLE
Add host entry to the end of the file with one command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,8 @@ From a new terminal on the host machine:
 
 ```
 sudo cp /private/etc/hosts /private/etc/hosts-backup
-sudo nano /private/etc/hosts
+echo "127.0.0.1 tide.local" >> /private/etc/hosts
 ```
-
-Use the arrow keys to navigate to the bottom of the hosts file and add a new host name.  
-
-```
-127.0.0.1 tide.local
-```
-
-When finished, hit `Control+O` followed by `ENTER/RETURN` to save changes to `/private/etc/hosts`, then hit `Control+X` to exit out of nano.
-
 
 ### Windows Environment
 


### PR DESCRIPTION
Instead of using Nano, just using linux internal features to add the entry to the end of the file.
This simplifies the steps needed to perform the wanted action and removes the dependency on `nano`.